### PR TITLE
Return 404 Not Found for non-existing redirect

### DIFF
--- a/redirect.php
+++ b/redirect.php
@@ -26,11 +26,11 @@ if ($query) {
 
 $mysqli->close();
 
-if(empty($redirect)) {
-    $redirect = BASEURL;
+if (empty($redirect)) {
+    header('HTTP/1.1 404 Not Found');
+    include('index.html');
 }
-
-header('HTTP/1.1 302 Found');
-header('Location: ' .  $redirect);
-exit();
-?>
+else {
+    header('HTTP/1.1 302 Found');
+    header('Location: ' .  $redirect);
+}


### PR DESCRIPTION
Include the `index.html` page without further adjustments (i.e. no 'Not Found' warning), but provide the correct header (404).
Fixes #7
